### PR TITLE
feat: Introduce Flake for development and builds

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url =
+      lock.nodes.flake-compat.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728492678,
+        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,146 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs =
+    { self, ... }@inputs:
+    let
+      forAllSystems =
+        function:
+        inputs.nixpkgs.lib.genAttrs
+          [
+            "x86_64-linux"
+            "aarch64-linux"
+          ]
+          (
+            system:
+            function (
+              import inputs.nixpkgs {
+                inherit system;
+                config.allowUnfree = true;
+              }
+            )
+          );
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          infinitime-nrf5-sdk = pkgs.nrf5-sdk.overrideAttrs (old: {
+            version = "15.3.0";
+            src = pkgs.fetchzip {
+              url = "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/sdks/nrf5/binaries/nrf5sdk153059ac345.zip";
+              sha256 = "sha256-pfmhbpgVv5x2ju489XcivguwpnofHbgVA7bFUJRTj08=";
+            };
+          });
+        in
+        with pkgs;
+        rec {
+          infinitime = stdenv.mkDerivation rec {
+            name = "infinitime";
+            version = "1.14.1";
+
+            src = fetchFromGitHub {
+              owner = "InfiniTimeOrg";
+              repo = "InfiniTime";
+              rev = "refs/tags/${version}";
+              hash = "sha256-IrsN+9LgEjgfoRR6H7FhsdLMK+GLxc41IBnSbdpwv/E=";
+              fetchSubmodules = true;
+            };
+
+            nativeBuildInputs = [
+              adafruit-nrfutil
+              nodePackages.lv_font_conv
+              patch
+              python3
+              python3.pkgs.cbor
+              python3.pkgs.click
+              python3.pkgs.cryptography
+              python3.pkgs.intelhex
+              python3.pkgs.pillow
+            ];
+
+            buildInputs = with pkgs; [ cmake ];
+
+            postPatch = ''
+              # /usr/bin/env is not available in the build sandbox
+              substituteInPlace src/displayapp/fonts/generate.py --replace "'/usr/bin/env', 'patch'" "'patch'"
+              substituteInPlace tools/mcuboot/imgtool.py --replace "/usr/bin/env python3" "${python3}/bin/python3"
+            '';
+
+            cmakeFlags =
+              let
+                lvImgConvPath = "${lv_img_conv.outPath}/bin";
+              in
+              [
+                ''-DARM_NONE_EABI_TOOLCHAIN_PATH=${gcc-arm-embedded-10}''
+                ''-DNRF5_SDK_PATH=${infinitime-nrf5-sdk}/share/nRF5_SDK''
+                ''-DBUILD_DFU=1''
+                ''-DBUILD_RESOURCES=1''
+                ''-DCMAKE_SOURCE_DIR=${src}''
+                ''-DCMAKE_PROGRAM_PATH=${lvImgConvPath}''
+              ];
+
+            installPhase = ''
+              SOURCES_DIR=${src} BUILD_DIR=. OUTPUT_DIR=$out ./post_build.sh
+            '';
+          };
+          default = infinitime;
+          lv_img_conv = python3Packages.buildPythonApplication rec {
+            pname = "lv_img_conv";
+            version = "unstable";
+            format = "other";
+
+            propagatedBuildInputs = with python3Packages; [ pillow ];
+
+            dontUnpack = true;
+            installPhase =
+              let
+                scriptPath = ./src/resources/lv_img_conv.py;
+              in
+              ''
+                install -Dm755 ${scriptPath} $out/bin/${pname}
+              '';
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        pkgs:
+        let
+          infinitime-nrf5-sdk = pkgs.nrf5-sdk.overrideAttrs (old: {
+            version = "15.3.0";
+            src = pkgs.fetchzip {
+              url = "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/sdks/nrf5/binaries/nrf5sdk153059ac345.zip";
+              sha256 = "sha256-pfmhbpgVv5x2ju489XcivguwpnofHbgVA7bFUJRTj08=";
+            };
+          });
+        in
+        with pkgs;
+        {
+          default = mkShell {
+            packages =
+              [
+                (writeShellScriptBin "cmake_infinitime" ''
+                  ${cmake}/bin/cmake -DARM_NONE_EABI_TOOLCHAIN_PATH="${gcc-arm-embedded-10}" \
+                        -DNRF5_SDK_PATH="${infinitime-nrf5-sdk}/share/nRF5_SDK" \
+                        "$@"
+                '')
+                ninja
+              ]
+              ++ (with self.packages.${pkgs.system}; [
+                infinitime
+                lv_img_conv
+              ]);
+          };
+        }
+      );
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  in
+  fetchTarball {
+    url =
+      lock.nodes.flake-compat.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }
+) { src = ./.; }).shellNix


### PR DESCRIPTION
This PR introduces a Nix flake, allowing for InfiniTime to be built as a Flake, including a FHS development environment.

It's derived from and
https://github.com/icewind1991/infinitime-builder/commit/c57c57f3c6a34c86eb816981d9b0ea56af4a09e5.

We also introduce `flake-compat`, allowing for non-Flake Nix mahcines to use the project as-is, both for building (`default.nix`), and development (`shell.nix`).

Additionally, we introduce `.envrc`, meaning that with `direnv`, the Nix Flake is activated automatically.